### PR TITLE
Disable iOS nuisances in search field. Fixes #11

### DIFF
--- a/src/getclojure/views/layout.clj
+++ b/src/getclojure/views/layout.clj
@@ -17,8 +17,10 @@
      (form-to
       [:get "/search"]
       (if query
-        (text-field {:placeholder "COMP AND JUXT"} "q" query)
-        (text-field {:placeholder "COMP AND JUXT"} "q"))
+        (text-field {:autocorrect "off" :autocapitalize "off" :autocomplete "off"
+                     :spellcheck "false" :placeholder "COMP AND JUXT"} "q" query)
+        (text-field {:autocorrect "off" :autocapitalize "off" :autocomplete "off"
+                     :spellcheck "false" :placeholder "COMP AND JUXT"} "q"))
       (hidden-field "num" 0)
       (submit-button {:id "search-box"} "search"))]))
 


### PR DESCRIPTION
Disable the three C's: correcting, completing and capitalizing.
